### PR TITLE
BUG FIX: Package test 'test_sesamize.R' requires 'IlluminaHumanMethylation450kmanifest'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Suggests: scales,
           FlowSorted.Blood.450k,
           dplyr,
           tidyr,
-          BiocStyle
+          BiocStyle,
+          IlluminaHumanMethylation450kmanifest
 Encoding: UTF-8
 VignetteBuilder: knitr
 URL: https://github.com/zwdzwd/sesame


### PR DESCRIPTION
Checking the package with `R CMD check --as-cran` reveals that package test 'test_sesamize.R' fails because 'IlluminaHumanMethylation450kmanifest' is not available.  This PR should fix that.

*   checking tests ...
    ```
    ...
      > test_check("sesame")
      ── Warning (test_sesamize.R:16:5): RGChannelSetToSigSet gives correct results ──
      there is no package called 'IlluminaHumanMethylation450kmanifest'

      ── ERROR (test_sesamize.R:16:5): RGChannelSetToSigSet gives correct results ────
      Error: cannot load manifest package IlluminaHumanMethylation450kmanifest
      Backtrace:
          █
       1. └─minfi::preprocessRaw(rgSet) test_sesamize.R:16:4
       2.   └─minfi::getManifestInfo(rgSet, "locusNames")
       3.     └─minfi::getProbeInfo(object, type = "I")
       4.       ├─minfi::getManifest(object)
       5.       └─minfi::getManifest(object)

      ══ testthat results  ═══════════════════════════════════════════════════════════
      Warning (test_sesamize.R:16:5): RGChannelSetToSigSet gives correct results
      ERROR (test_sesamize.R:16:5): RGChannelSetToSigSet gives correct results

      [ FAIL 1 | WARN 1 | SKIP 0 | PASS 15 ]
      Error: Test failures
      Execution halted
    ```
