### PR TITLE
added F test check for summaryExtractTest function

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -134,18 +134,22 @@ summaryExtractTest <- function(smry) {
         x$coefficients[,"Pr(>|t|)"] }))))
     rownames(pvals) <- names(smry)
     colnames(pvals) <- paste0("Pval_", colnames(pvals))
-    f_pvals <- do.call(rbind, lapply(smry, function(x) {
-        x$Ftest["pval",,drop=FALSE] }))
-    rownames(f_pvals) <- names(smry)
-    colnames(f_pvals) <- paste0("FPval_", colnames(f_pvals))
-    contr2lvs <- attr(smry, "contr2lvs")
-    effsize <- do.call(cbind, lapply(names(contr2lvs), function(cont) {
-        lvs <- contr2lvs[[cont]]
-        lvs <- lvs[2:length(lvs)]
-        lvs <- lvs[paste0("Est_", cont, lvs) %in% colnames(est)]
-        apply(est[, paste0("Est_", cont, lvs),drop=FALSE], 1, function(x) {
-            max(x,0) - min(x,0) }) }))
-    colnames(effsize) <- paste0("Eff_", names(contr2lvs))
+    if(is.null(smry[[1]]$Ftest)) {
+        return(cbind(est,pvals))
+    } else {
+        f_pvals <- do.call(rbind, lapply(smry, function(x) {
+            x$Ftest["pval",,drop=FALSE] }))
+        rownames(f_pvals) <- names(smry)
+        colnames(f_pvals) <- paste0("FPval_", colnames(f_pvals))
+        contr2lvs <- attr(smry, "contr2lvs")
+        effsize <- do.call(cbind, lapply(names(contr2lvs), function(cont) {
+            lvs <- contr2lvs[[cont]]
+            lvs <- lvs[2:length(lvs)]
+            lvs <- lvs[paste0("Est_", cont, lvs) %in% colnames(est)]
+            apply(est[, paste0("Est_", cont, lvs),drop=FALSE], 1, function(x) {
+                max(x,0) - min(x,0) }) }))
+        colnames(effsize) <- paste0("Eff_", names(contr2lvs))
+    }
     cbind(est, pvals, f_pvals, effsize)
 }
 


### PR DESCRIPTION
function currently throws error if only modeling with continuous variables (and no F testing) was done. If no F test results found, modified function just returns data from continuous variables 