### PR TITLE
added replace.probes.with.loci option (new default)

### DIFF
--- a/R/visualizeHelper.R
+++ b/R/visualizeHelper.R
@@ -150,7 +150,9 @@ plotCytoBand <- function(
 assemble_plots <- function(
     betas, txns, probes, plt.txns, plt.mapLines, plt.cytoband,
     heat.height = NULL, 
-    show.probeNames = TRUE, replace.probes.with.loci = TRUE, show.samples.n = NULL,
+    show.probeNames = TRUE, replace.probes.with.loci = TRUE, 
+    ##show.regulatory.features = TRUE,  // working on currently
+    show.samples.n = NULL,
     show.sampleNames = TRUE, sample.name.fontsize = 10,
     dmin = 0, dmax = 1) {
 
@@ -166,9 +168,20 @@ assemble_plots <- function(
   probes.df
   
   betas  <- merge(probes.df[c("genomic.loci", "probes")], betas, by = "probes")
+      
+#below 'if/else statement' will determine if any genomic loci coordinates are repeated, if so, de-duplicate by paste0'ing together probe_ID and genomic loci by an '_' in between and setting that to the row.name, instead of just the genomic.loci
+#for duplicates only, the paste0'd (combined probe_ID and genomic loci coordinates) will be their heatmap "x-axis", otherwise only genomic loci coordinate will be used
+  if (any(duplicated(betas$genomic.loci))) {
+      
+betas[which(duplicated(betas$genomic.loci)), "redundant_loci"] <- c('TRUE')
+rownames(betas)[which(betas$redundant_loci == TRUE)] <- paste0(betas[which(betas$redundant_loci == TRUE),"probes"], "_", betas[which(betas$redundant_loci == TRUE),"genomic.loci"])
+rownames(betas)[which(is.na(betas$redundant_loci))] <- betas[which(is.na(betas$redundant_loci)), "genomic.loci"]
+      betas$redundant_loci <- NULL
+      
+      } else {
   
   row.names(betas) <- betas$genomic.loci
-  
+      }
   betas$probes <- NULL
   betas$genomic.loci <- NULL
   betas <- as.matrix(betas)

--- a/R/visualizeHelper.R
+++ b/R/visualizeHelper.R
@@ -150,11 +150,33 @@ plotCytoBand <- function(
 assemble_plots <- function(
     betas, txns, probes, plt.txns, plt.mapLines, plt.cytoband,
     heat.height = NULL, 
-    show.probeNames = TRUE, show.samples.n = NULL,
+    show.probeNames = TRUE, replace.probes.with.loci = TRUE, show.samples.n = NULL,
     show.sampleNames = TRUE, sample.name.fontsize = 10,
     dmin = 0, dmax = 1) {
-    
-    if (is.null(show.samples.n)) { show.samples.n <- ncol(betas); }
+
+  if (replace.probes.with.loci) {
+  #converting probes to genomic loci in betas 'rownames' //START
+  betas <- GenomicRanges::as.data.frame(betas)
+  
+  betas["probes"]<- rownames(betas)
+  
+  probes.df <- GenomicRanges::as.data.frame(probes)
+  probes.df["genomic.loci"] <- paste0(probes.df$seqnames, ":", probes.df$start, "-", probes.df$end)
+  probes.df["probes"]<- row.names(probes.df)
+  probes.df
+  
+  betas  <- merge(probes.df[c("genomic.loci", "probes")], betas, by = "probes")
+  
+  row.names(betas) <- betas$genomic.loci
+  
+  betas$probes <- NULL
+  betas$genomic.loci <- NULL
+  betas <- as.matrix(betas)
+  #converting probes to genomic loci in betas 'rownames' //END
+  }
+  
+  
+  if (is.null(show.samples.n)) { show.samples.n <- ncol(betas); }
     if (is.null(heat.height) && length(txns) > 0) {
         heat.height <- 10 / length(txns); }
     w <- WGrob(plt.txns, name = 'txn')

--- a/R/visualizeHelper.R
+++ b/R/visualizeHelper.R
@@ -185,14 +185,13 @@ rename_probes_to_loci_and_de_duplicate_if_needed function(probes.list.or.betas, 
 assemble_plots <- function(
     betas, txns, probes, plt.txns, plt.mapLines, plt.cytoband,
     heat.height = NULL, 
-    show.probeNames = TRUE, replace.probes.with.loci = TRUE, 
-    show.regulatory.features = TRUE, #only done for genome 'mm39' and 'MM285'
+    show.probeNames = TRUE, 
+    replace.probes.with.loci_and_show.regulatory.features = TRUE,
     show.samples.n = NULL,
     show.sampleNames = TRUE, sample.name.fontsize = 10,
     dmin = 0, dmax = 1) {
-
- if (show.regulatory.features = TRUE && replace.probes.with.loci = TRUE) {
-  if (genome == 'mm39' && platform == 'MM285') {
+#replace.probes.with.loci_and_show.regulatory.features = TRUE is only really meant to be used with (mouse) mm39, since the regulatory features were obtained from Ensembl 108 (mouse) mm39
+ if (replace.probes.with.loci_and_show.regulatory.features) {
       #START - Addition by Pratik - bring in regulatory features from mft
       mft <- sesameDataGet(sprintf('%s.%s.manifest', platform, genome))
       probe.list <- data.frame(mft[which(names(mft) %in% rownames(betas))])
@@ -217,13 +216,10 @@ cpg_island_color <- pals::tol.rainbow(n=12)[6]
 names(cpg_island_color) <- "CpG Island"
 #END - PRATIK - add colors for features
       
-      rename_probes_to_loci_and_de_duplicate_if_needed(betas, probes)
+      betas <- rename_probes_to_loci_and_de_duplicate_if_needed(betas, probes)
         }
      }
     
-if (show.regulatory.features = FALSE && replace.probes.with.loci = TRUE) {
-betas <- rename_probes_to_loci_and_de_duplicate_if_needed(probe.list, probes)
-}
   
   
   if (is.null(show.samples.n)) { show.samples.n <- ncol(betas); }
@@ -242,6 +238,13 @@ betas <- rename_probes_to_loci_and_de_duplicate_if_needed(probe.list, probes)
         yticklabels.n = show.samples.n,
         xticklabels.n = length(probes))
     w <- w + WGrob(plt.cytoband, TopOf('txn', height=0.15))
-    if 
-    w
+    if (replace.probes.with.loci_and_show.regulatory.features) {
+    w <- w + WLegendV(x = "betas", RightOf("betas"), n.text = 2, "betalegend", decreasing = TRUE)  +
+             WColorBarH(probe.list$CpG_Island, Beneath('betas', v.scale.proportional = TRUE), cmp=CMPar(brewer.name= 'Set2'), label = "CpG Island", label.side = 'l', "CpG") +
+             WColorBarH(probe.list$regulatory_feature, Beneath(v.scale.proportional = TRUE), cmp=CMPar(brewer.name= 'Paired', label2color = mycolors), label = "Genomic Feature Type", label.side = 'l', 'GFT') +
+             WLabel(x= "Beta Values", TopOf("betalegend", pad=0.1), fontsize = 15) +
+             WLegendV(x= "CpG", BottomRightOf("betas",just = c('center', 'center'), h.pad = .10, v.pad = -.3), height = rel(la.size), label.fontsize = sample.name.fontsize, yticklabel.pad=0.05) +
+             WLegendV(x= "GFT",Beneath(), label.fontsize = sample.name.fontsize, yticklabel.pad=0.05, height = .3)
+     w
+  }
 }


### PR DESCRIPTION
### added replace.probes.with.loci option (new default)
### Completed:
if replace.probes.with.loci is set to TRUE, it will replace probes names to loci in the drawn heatmap (new default)
if replace.probes.with.loci is set to FALSE, it will keep probe names

### How to use:
**replace.probes.with.loci = TRUE (explicit)**
```
visualizeGene(betas = se_data, gene_name = 'Pdx1', platform = 'MM285', genome = 'mm10', 
              show.sampleNames = FALSE, replace.probes.with.loci=TRUE)
```
**Output:**

![true_image](https://user-images.githubusercontent.com/71743538/202339608-5e786e7d-8a6b-40be-9f47-32ace4f287a9.png)





**replace.probes.with.loci = FALSE (explicit)**

```
visualizeGene(betas = se_data, gene_name = 'Pdx1', platform = 'MM285', genome = 'mm10', replace.probes.with.loci=FALSE,
              show.sampleNames = FALSE)
```
**Output:**
![false_image](https://user-images.githubusercontent.com/71743538/202339722-57be91d9-eccc-499f-b772-afd08725ec2c.png)



### To do:

- add the genomic features from the [mm39 ensembl 108 regulatory build](https://ftp.ensembl.org/pub/release-108/regulation/mus_musculus/mus_musculus.GRCm39.Regulatory_Build.regulatory_features.20220822.gff.gz) (I have already done parsing for the gff file, and integrated it to the mm39 manifest and the loci manually [not through a _fancy_ function 🥸] now I just need to plot it in the heatmap neatly)

- I also may play around with the arithmetic for resizing the heatmaps, if I can't see the whole heatmap after doing the regulatory feature changes [i think this could be solved through just generated bigger plots]

 