### PR TITLE
fix spelling error in addMask docs

### DIFF
--- a/R/mask.R
+++ b/R/mask.R
@@ -1,8 +1,8 @@
 #' Add probes to mask
 #'
 #' This function essentially merge existing probe masking
-#' with new prboes to mask
-#' 
+#' with new probes to mask
+#'
 #' @param sdf a \code{SigDF}
 #' @param probes a vector of probe IDs or a logical vector with TRUE
 #' representing masked probes

--- a/man/addMask.Rd
+++ b/man/addMask.Rd
@@ -17,7 +17,7 @@ a \code{SigDF} with added mask
 }
 \description{
 This function essentially merge existing probe masking
-with new prboes to mask
+with new probes to mask
 }
 \examples{
 sdf <- sesameDataGet('EPIC.1.SigDF')


### PR DESCRIPTION
This PR fixes a tiny spelling error in the docs for the `addMask` function. 