### PR TITLE
Allow platform inference to be more sensitive

### DIFF
--- a/R/sesame.R
+++ b/R/sesame.R
@@ -275,11 +275,15 @@ getAFs <- function(sdf, ...) {
 inferPlatformFromTango <- function(res) {
     sig <- sesameDataGet('idatSignature')
     cnts <- vapply(
-        sig, function(x) sum(x %in% rownames(res$Quants)), integer(1))
-    if (max(cnts) < min(vapply(sig, length, numeric(1)))) {
-        return(NULL)
+        sig, 
+        function(x) sum(x %in% rownames(res$Quants)), 
+        integer(1)
+    )
+    # If more than one platform has hits:
+    if (sum(cnts > 0) > 1) {
+      return(NULL)
     }
-    names(which.max(cnts))
+    names(cnts[which.max(cnts)])
 }
 
 ## Import one IDAT file


### PR DESCRIPTION
Currently `inferPlatformFromTango` fails if any of the 20 probes are missing. Some files (e.g ftp.ncbi.nlm.nih.gov/geo/samples/GSM6034nnn/GSM6034891/suppl/GSM6034891_GCC28_P_204411500039_R08C01_Red.idat.gz) don't have all the probes. 