### PR TITLE
Fix impute.R by replacing all instances of df$data with df

### DIFF
--- a/R/impute.R
+++ b/R/impute.R
@@ -27,7 +27,7 @@ imputeBetas <- function(betas, platform = NULL, BPPARAM = SerialParam(),
     
     platform <- sesameData_check_platform(platform, names(betas))
     df <- sesameDataGet(sprintf("%s.imputationDefault", platform))
-    d2q <- match(names(betas), df$Probe_ID)
+    d2q <- match(names(betas), df$Blood$Probe_ID) #currently Blood is the only dataset in df, this will need to be changed if more datasets become available
     celltype <- names(which.max(vapply(df, function(x) cor(
         betas, x$median[d2q], use="na.or.complete"), numeric(1))))
     if (is.null(celltype)) {

--- a/R/impute.R
+++ b/R/impute.R
@@ -28,14 +28,14 @@ imputeBetas <- function(betas, platform = NULL, BPPARAM = SerialParam(),
     platform <- sesameData_check_platform(platform, names(betas))
     df <- sesameDataGet(sprintf("%s.imputationDefault", platform))
     d2q <- match(names(betas), df$Probe_ID)
-    celltype <- names(which.max(vapply(df$data, function(x) cor(
+    celltype <- names(which.max(vapply(df, function(x) cor(
         betas, x$median[d2q], use="na.or.complete"), numeric(1))))
     if (is.null(celltype)) {
         celltype <- "Blood"
     }
     idx <- is.na(betas)
-    mn <- df$data[[celltype]]$median[d2q][idx]
-    sd <- df$data[[celltype]]$sd[d2q][idx]
+    mn <- df[[celltype]]$median[d2q][idx]
+    sd <- df[[celltype]]$sd[d2q][idx]
     mn[sd > sd_max] <- NA
     betas[idx] <- mn
     betas
@@ -77,7 +77,7 @@ imputeBetasByGenomicNeighbors <- function(betas, platform = NULL,
     df$dist <- pmax(df$d1, df$d2)
     df <- summarize(slice_min(group_by(df, .data[['cg']]),
         n = max_neighbors, order_by = .data[['dist']]),
-        mbetas = mean(.data[['betas']]))
+        mbets = mean(.data[['betas']]))
     betas[df$cg] <- df$mbetas
     betas
 }


### PR DESCRIPTION
This pull request fixes an error when using the mLiftOver function to convert an EPICv2 beta matrix to EPIC or 450k if impute=TRUE

Error details:
sesame version: 1.23.9
I got the following error when converting an EPICv2 beta matrix (with 208 samples) to EPIC with mLiftOver function and imputation:
```
betas_EPICv1 <- mLiftOver(betas_EPICv2, platform='EPIC', celltype=NULL, impute=TRUE) #error also occurs if platform='HM450'

Platform set to: EPICv2
Error: BiocParallel errors
  1 remote errors, element index: 1
  207 unevaluated and other errors
  first remote error:
Error in betas[idx] <- mn: replacement has length zero
```

I think this is due to an error in the imputeBetas function called within mLiftOver. This function imports the imputation datasets as follows:
```
df <- sesameDataGet(sprintf("%s.imputationDefault", platform)) #platform="EPIC" or "HM450"
```
The df dataset is referenced later in the function, e.g.
```
mn <- df$data[[celltype]]$median[d2q][idx]
    sd <- df$data[[celltype]]$sd[d2q][idx]
```
However `df$data` does not exist. Looking inside the df object, it's a list where the only name is Blood (true of both EPIC and 450k datasets)
```
head(df)
$Blood
#  A tibble: 866,553 × 5
Probe_ID    mean median   cnt      sd
   <chr>      <dbl>  <dbl> <dbl>   <dbl>
 1 cg00000029 0.703  0.713  2000 0.102
 2 cg00000103 0.936  0.941  2000 0.0306
 3 cg00000109 0.934  0.938  2000 0.0180
 4 cg00000155 0.955  0.959  2000 0.0359
 5 cg00000158 0.966  0.966  2000 0.00759
 6 cg00000165 0.194  0.189  2000 0.0521
 7 cg00000221 0.917  0.920  2000 0.0199
 8 cg00000236 0.862  0.866  2000 0.0553
 9 cg00000289 0.874  0.880  2000 0.0380
10 cg00000292 0.878  0.879  2000 0.0305
```

Therefore, replacing all instances of `df$data` with `df` in the imputeBetas function fixes this error. After making a local copy of the imputeBetas and mLiftOver functions with this change I was able to run mLiftOver with no error.