### PR TITLE
fix sesameQCtoDF column subsetting

### DIFF
--- a/R/QC.R
+++ b/R/QC.R
@@ -43,7 +43,7 @@ dataFrame2sesameQC <- function(df) {
 #' @export
 sesameQCtoDF <- function(qcs, cols=c("frac_dt_cg","RGdistort", "RGratio")) {
     if (is.list(qcs)) {
-        df <- bind_rows(lapply(qcs, sesameQCtoDF))
+        df <- bind_rows(lapply(qcs, sesameQCtoDF, cols=cols))
     } else if (is(qcs, "sesameQC")) {
         df <- as.data.frame(qcs@stat)
     }


### PR DESCRIPTION
This pull request fixes an issue with column subsetting in sesameQCtoDF.

When qcs is a list, sesameQCtoDF returns the three default columns.

```
qc <- openSesame("test", prep="", func=sesameQC_calcStats)
qc_df<- sesameQCtoDF(qc, cols=c("num_dtna","frac_dtna","num_dt"))
qc_df
                  IDAT frac_dt_cg  RGratio RGdistort
1  206129770003_R01C01  0.8423470 1.535159  1.336828
2  206129770003_R02C01  0.9325517 1.409389  1.271266
3  206129770003_R03C01  0.7275575 1.913057  1.147329
```

This can be fixed by passing cols to the recursive call to sesameQCtoDF

```
sesame_checkVersion()
SeSAMe requires matched versions of R, sesame, sesameData and ExperimentHub.
Here is the current versions installed:
R: 4.4.2
Bioconductor: 3.20
sesame: 1.24.0
sesameData: 1.24.0
ExperimentHub: 2.14.0
```
