### PR TITLE
fix: column names in readControls(..)

### DIFF
--- a/R/sesame.R
+++ b/R/sesame.R
@@ -380,7 +380,7 @@ readControls <- function(dm, controls) {
         ctl <- as.data.frame(dm[match(controls$Address, rownames(dm)),])
         rownames(ctl) <- make.names(controls$Name, unique=TRUE)
         ctl <- cbind(ctl, controls[, c("Color_Channel","Type")])
-        colnames(ctl) <- c('G','R','col','type')
+        colnames(ctl) <- c('G','R','GN','RN','col','type')
         ctl <- ctl[!(is.na(ctl$G)|is.na(ctl$R)),] # no NA in controls
     } else {
         ctl <- as.data.frame(chipAddressToSignal(dm, controls))


### PR DESCRIPTION
Change https://github.com/zwdzwd/sesame/commit/1a92c6461b26207987c5ae722639d6fcf01febc4 make readIDAT1(..) return two additional columns "GN" and "RN". This should have been updated here in readControls(..) as well, but never was.

Without this change readIDATpair(..) reads in EPICv1 IDAT files and mangles their controls dataframe attribute so they end up with the column names: G R col type NA NA, where type is actually GN. 

This is why dyeBiasCorr(..) currently fails on those same sdf with: Error in normControls(sdf, average = TRUE) : 
  No normalization control probes found!

This should fix https://github.com/zwdzwd/sesame/issues/176